### PR TITLE
refactor: rename API query parameters from a/b to x/y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ make demo-breaking-change
 
 ### API Endpoints
 
-All endpoints accept query params `a` and `b` (numbers) and return `{"result": <number>}`:
+All endpoints accept query params `x` and `y` (numbers) and return `{"result": <number>}`:
 - `GET /add`, `/subtract`, `/multiply`, `/divide`
 - `GET /health` returns `{"status": "healthy"}`
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ help:
 build:
 	docker compose build
 
-up:
+up: build
 	docker compose up -d
 
 down:
@@ -94,17 +94,17 @@ clean:
 test-producer:
 	@echo "Testing producer endpoints..."
 	@echo ""
-	@echo "GET /add?a=5&b=3"
-	@curl -s "http://localhost:10001/add?a=5&b=3" | jq .
+	@echo "GET /add?x=5&y=3"
+	@curl -s "http://localhost:10001/add?x=5&y=3" | jq .
 	@echo ""
-	@echo "GET /subtract?a=10&b=4"
-	@curl -s "http://localhost:10001/subtract?a=10&b=4" | jq .
+	@echo "GET /subtract?x=10&y=4"
+	@curl -s "http://localhost:10001/subtract?x=10&y=4" | jq .
 	@echo ""
-	@echo "GET /multiply?a=4&b=7"
-	@curl -s "http://localhost:10001/multiply?a=4&b=7" | jq .
+	@echo "GET /multiply?x=4&y=7"
+	@curl -s "http://localhost:10001/multiply?x=4&y=7" | jq .
 	@echo ""
-	@echo "GET /divide?a=10&b=2"
-	@curl -s "http://localhost:10001/divide?a=10&b=2" | jq .
+	@echo "GET /divide?x=10&y=2"
+	@curl -s "http://localhost:10001/divide?x=10&y=2" | jq .
 	@echo ""
 	@echo "GET /health"
 	@curl -s "http://localhost:10001/health" | jq .

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ This demo application showcases the **[Contract Validator Toolkit (CVT)](https:/
 
 A Go HTTP server implementing the Calculator API with 4 endpoints:
 
-- `GET /add?a=<num>&b=<num>` - Add two numbers
-- `GET /subtract?a=<num>&b=<num>` - Subtract two numbers
-- `GET /multiply?a=<num>&b=<num>` - Multiply two numbers
-- `GET /divide?a=<num>&b=<num>` - Divide two numbers
+- `GET /add?x=<num>&y=<num>` - Add two numbers
+- `GET /subtract?x=<num>&y=<num>` - Subtract two numbers
+- `GET /multiply?x=<num>&y=<num>` - Multiply two numbers
+- `GET /divide?x=<num>&y=<num>` - Divide two numbers
 
 ```bash
-curl "http://localhost:10001/add?a=5&b=3"       # {"result":8}
-curl "http://localhost:10001/subtract?a=10&b=4" # {"result":6}
-curl "http://localhost:10001/multiply?a=4&b=7"  # {"result":28}
-curl "http://localhost:10001/divide?a=20&b=4"   # {"result":5}
+curl "http://localhost:10001/add?x=5&y=3"       # {"result":8}
+curl "http://localhost:10001/subtract?x=10&y=4" # {"result":6}
+curl "http://localhost:10001/multiply?x=4&y=7"  # {"result":28}
+curl "http://localhost:10001/divide?x=20&y=4"   # {"result":5}
 ```
 
 The producer uses CVT middleware for runtime contract validation against `calculator-api.yaml`.
@@ -107,7 +107,7 @@ docker compose up -d
 make test-producer
 
 # Or manually:
-curl "http://localhost:10001/add?a=5&b=3"
+curl "http://localhost:10001/add?x=5&y=3"
 # Expected: {"result":8}
 ```
 
@@ -292,17 +292,17 @@ cvt can-i-deploy --schema calculator-api --version 2.0.0 --env demo
 
 | Endpoint    | Method | Parameters         | Response                |
 | ----------- | ------ | ------------------ | ----------------------- |
-| `/add`      | GET    | `a`, `b` (numbers) | `{"result": <number>}`  |
-| `/subtract` | GET    | `a`, `b` (numbers) | `{"result": <number>}`  |
-| `/multiply` | GET    | `a`, `b` (numbers) | `{"result": <number>}`  |
-| `/divide`   | GET    | `a`, `b` (numbers) | `{"result": <number>}`  |
+| `/add`      | GET    | `x`, `y` (numbers) | `{"result": <number>}`  |
+| `/subtract` | GET    | `x`, `y` (numbers) | `{"result": <number>}`  |
+| `/multiply` | GET    | `x`, `y` (numbers) | `{"result": <number>}`  |
+| `/divide`   | GET    | `x`, `y` (numbers) | `{"result": <number>}`  |
 | `/health`   | GET    | -                  | `{"status": "healthy"}` |
 
 ### Error Responses
 
 All endpoints return 400 Bad Request for:
 
-- Missing `a` or `b` parameters
+- Missing `x` or `y` parameters
 - Non-numeric parameter values
 - Division by zero (for `/divide`)
 

--- a/consumer-1/main.js
+++ b/consumer-1/main.js
@@ -3,8 +3,8 @@
  * Consumer-1: A CLI tool that uses the Calculator API for add and subtract operations.
  *
  * Usage:
- *   node main.js add <a> <b> [--validate]
- *   node main.js subtract <a> <b> [--validate]
+ *   node main.js add <x> <y> [--validate]
+ *   node main.js subtract <x> <y> [--validate]
  *
  * Options:
  *   --validate  Enable CVT contract validation (default: off)
@@ -84,14 +84,14 @@ async function createClient(validate) {
 /**
  * Performs an add operation.
  */
-async function add(a, b, options) {
+async function add(x, y, options) {
   try {
     const client = await createClient(options.validate);
     const response = await client.get('/add', {
-      params: { a, b },
+      params: { x, y },
     });
 
-    console.log(`${a} + ${b} = ${response.data.result}`);
+    console.log(`${x} + ${y} = ${response.data.result}`);
   } catch (error) {
     handleError(error);
   }
@@ -100,14 +100,14 @@ async function add(a, b, options) {
 /**
  * Performs a subtract operation.
  */
-async function subtract(a, b, options) {
+async function subtract(x, y, options) {
   try {
     const client = await createClient(options.validate);
     const response = await client.get('/subtract', {
-      params: { a, b },
+      params: { x, y },
     });
 
-    console.log(`${a} - ${b} = ${response.data.result}`);
+    console.log(`${x} - ${y} = ${response.data.result}`);
   } catch (error) {
     handleError(error);
   }
@@ -142,35 +142,35 @@ program
   .version('1.0.0');
 
 program
-  .command('add <a> <b>')
+  .command('add <x> <y>')
   .description('Add two numbers')
   .option('--validate', 'Enable CVT contract validation', false)
-  .action((a, b, options) => {
-    const numA = parseFloat(a);
-    const numB = parseFloat(b);
+  .action((x, y, options) => {
+    const numX = parseFloat(x);
+    const numY = parseFloat(y);
 
-    if (isNaN(numA) || isNaN(numB)) {
+    if (isNaN(numX) || isNaN(numY)) {
       console.error('Error: Both arguments must be valid numbers');
       process.exit(1);
     }
 
-    add(numA, numB, options);
+    add(numX, numY, options);
   });
 
 program
-  .command('subtract <a> <b>')
+  .command('subtract <x> <y>')
   .description('Subtract two numbers')
   .option('--validate', 'Enable CVT contract validation', false)
-  .action((a, b, options) => {
-    const numA = parseFloat(a);
-    const numB = parseFloat(b);
+  .action((x, y, options) => {
+    const numX = parseFloat(x);
+    const numY = parseFloat(y);
 
-    if (isNaN(numA) || isNaN(numB)) {
+    if (isNaN(numX) || isNaN(numY)) {
       console.error('Error: Both arguments must be valid numbers');
       process.exit(1);
     }
 
-    subtract(numA, numB, options);
+    subtract(numX, numY, options);
   });
 
 program.parse();

--- a/consumer-1/tests/README.md
+++ b/consumer-1/tests/README.md
@@ -81,7 +81,7 @@ const adapter = createAxiosAdapter({
   validator,
   autoValidate: true,
 });
-await client.get("/add", { params: { a: 5, b: 3 } });
+await client.get("/add", { params: { x: 5, y: 3 } });
 // Validation happens automatically
 ```
 
@@ -90,7 +90,7 @@ await client.get("/add", { params: { a: 5, b: 3 } });
 Tests that use `createMockAdapter()` to generate schema-compliant responses without a real producer. Useful for unit testing and capturing interactions.
 
 ```javascript
-const response = await mock.fetch("http://calculator-api/add?a=5&b=3");
+const response = await mock.fetch("http://calculator-api/add?x=5&y=3");
 // Response is generated from schema, no real HTTP call
 ```
 
@@ -110,8 +110,8 @@ const consumer = await validator.registerConsumer({ usedEndpoints: [...] });
 
 Consumer-1 uses these Calculator API endpoints:
 
-- `GET /add?a={number}&b={number}` - Addition
-- `GET /subtract?a={number}&b={number}` - Subtraction
+- `GET /add?x={number}&y={number}` - Addition
+- `GET /subtract?x={number}&y={number}` - Subtraction
 
 ## Environment Variables
 

--- a/consumer-1/tests/adapter.test.js
+++ b/consumer-1/tests/adapter.test.js
@@ -62,7 +62,7 @@ describe('HTTP Adapter Approach', () => {
 
   describe('/add endpoint with automatic validation', () => {
     test('should automatically validate add operation', async () => {
-      const response = await client.get('/add', { params: { a: 5, b: 3 } });
+      const response = await client.get('/add', { params: { x: 5, y: 3 } });
 
       expect(response.status).toBe(200);
       expect(response.data.result).toBe(8);
@@ -73,7 +73,7 @@ describe('HTTP Adapter Approach', () => {
     });
 
     test('should capture request and response details', async () => {
-      await client.get('/add', { params: { a: 10, b: 20 } });
+      await client.get('/add', { params: { x: 10, y: 20 } });
 
       const interactions = adapter.getInteractions();
       expect(interactions.length).toBe(1);
@@ -88,7 +88,7 @@ describe('HTTP Adapter Approach', () => {
 
   describe('/subtract endpoint with automatic validation', () => {
     test('should automatically validate subtract operation', async () => {
-      const response = await client.get('/subtract', { params: { a: 15, b: 7 } });
+      const response = await client.get('/subtract', { params: { x: 15, y: 7 } });
 
       expect(response.status).toBe(200);
       expect(response.data.result).toBe(8);
@@ -99,7 +99,7 @@ describe('HTTP Adapter Approach', () => {
     });
 
     test('should handle negative result correctly', async () => {
-      const response = await client.get('/subtract', { params: { a: 3, b: 10 } });
+      const response = await client.get('/subtract', { params: { x: 3, y: 10 } });
 
       expect(response.status).toBe(200);
       expect(response.data.result).toBe(-7);
@@ -111,9 +111,9 @@ describe('HTTP Adapter Approach', () => {
 
   describe('multiple operations', () => {
     test('should capture multiple interactions', async () => {
-      await client.get('/add', { params: { a: 1, b: 2 } });
-      await client.get('/subtract', { params: { a: 5, b: 3 } });
-      await client.get('/add', { params: { a: 10, b: 10 } });
+      await client.get('/add', { params: { x: 1, y: 2 } });
+      await client.get('/subtract', { params: { x: 5, y: 3 } });
+      await client.get('/add', { params: { x: 10, y: 10 } });
 
       const interactions = adapter.getInteractions();
       expect(interactions.length).toBe(3);

--- a/consumer-1/tests/manual.test.js
+++ b/consumer-1/tests/manual.test.js
@@ -42,11 +42,11 @@ describe('Manual Validation Approach', () => {
 
   describe('/add endpoint', () => {
     test('should validate successful add operation', async () => {
-      const response = await client.get('/add', { params: { a: 5, b: 3 } });
+      const response = await client.get('/add', { params: { x: 5, y: 3 } });
 
       const request = {
         method: 'GET',
-        path: '/add?a=5&b=3',
+        path: '/add?x=5&y=3',
         headers: {},
       };
 
@@ -66,7 +66,7 @@ describe('Manual Validation Approach', () => {
     test('should detect missing result field in response', async () => {
       const request = {
         method: 'GET',
-        path: '/add?a=5&b=3',
+        path: '/add?x=5&y=3',
         headers: {},
       };
 
@@ -87,7 +87,7 @@ describe('Manual Validation Approach', () => {
       // Using valid request params since CVT validates the entire request/response pair
       const request = {
         method: 'GET',
-        path: '/add?a=5&b=3',
+        path: '/add?x=5&y=3',
         headers: {},
       };
 
@@ -105,11 +105,11 @@ describe('Manual Validation Approach', () => {
 
   describe('/subtract endpoint', () => {
     test('should validate successful subtract operation', async () => {
-      const response = await client.get('/subtract', { params: { a: 10, b: 4 } });
+      const response = await client.get('/subtract', { params: { x: 10, y: 4 } });
 
       const request = {
         method: 'GET',
-        path: '/subtract?a=10&b=4',
+        path: '/subtract?x=10&y=4',
         headers: {},
       };
 
@@ -129,7 +129,7 @@ describe('Manual Validation Approach', () => {
     test('should detect incorrect response structure', async () => {
       const request = {
         method: 'GET',
-        path: '/subtract?a=10&b=4',
+        path: '/subtract?x=10&y=4',
         headers: {},
       };
 

--- a/consumer-1/tests/mock.test.js
+++ b/consumer-1/tests/mock.test.js
@@ -50,7 +50,7 @@ describe('Mock Client Approach', () => {
 
   describe('/add endpoint mocking', () => {
     test('should generate valid mock response for add', async () => {
-      const response = await mock.fetch('http://calculator-api/add?a=5&b=3');
+      const response = await mock.fetch('http://calculator-api/add?x=5&y=3');
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -59,7 +59,7 @@ describe('Mock Client Approach', () => {
     });
 
     test('should capture mock interactions', async () => {
-      await mock.fetch('http://calculator-api/add?a=10&b=20');
+      await mock.fetch('http://calculator-api/add?x=10&y=20');
 
       const interactions = mock.getInteractions();
       expect(interactions.length).toBe(1);
@@ -68,11 +68,11 @@ describe('Mock Client Approach', () => {
     });
 
     test('should generate response matching schema', async () => {
-      const response = await mock.fetch('http://calculator-api/add?a=1&b=1');
+      const response = await mock.fetch('http://calculator-api/add?x=1&y=1');
       const data = await response.json();
 
       const validationResult = await validator.validate(
-        { method: 'GET', path: '/add?a=1&b=1', headers: {} },
+        { method: 'GET', path: '/add?x=1&y=1', headers: {} },
         { statusCode: 200, headers: { 'content-type': 'application/json' }, body: data }
       );
 
@@ -82,7 +82,7 @@ describe('Mock Client Approach', () => {
 
   describe('/subtract endpoint mocking', () => {
     test('should generate valid mock response for subtract', async () => {
-      const response = await mock.fetch('http://calculator-api/subtract?a=10&b=4');
+      const response = await mock.fetch('http://calculator-api/subtract?x=10&y=4');
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -91,7 +91,7 @@ describe('Mock Client Approach', () => {
     });
 
     test('should capture subtract interaction', async () => {
-      await mock.fetch('http://calculator-api/subtract?a=100&b=50');
+      await mock.fetch('http://calculator-api/subtract?x=100&y=50');
 
       const interactions = mock.getInteractions();
       expect(interactions.length).toBe(1);
@@ -101,8 +101,8 @@ describe('Mock Client Approach', () => {
 
   describe('interaction capture for registration', () => {
     test('should capture all Consumer-1 endpoints for registration', async () => {
-      await mock.fetch('http://calculator-api/add?a=5&b=3');
-      await mock.fetch('http://calculator-api/subtract?a=10&b=4');
+      await mock.fetch('http://calculator-api/add?x=5&y=3');
+      await mock.fetch('http://calculator-api/subtract?x=10&y=4');
 
       const interactions = mock.getInteractions();
       expect(interactions.length).toBe(2);

--- a/consumer-1/tests/registration.test.js
+++ b/consumer-1/tests/registration.test.js
@@ -51,8 +51,8 @@ describe('Consumer Registration', () => {
 
   describe('Auto-registration from interactions', () => {
     test('should capture interactions for auto-registration', async () => {
-      await mock.fetch('http://calculator-api/add?a=5&b=3');
-      await mock.fetch('http://calculator-api/subtract?a=10&b=4');
+      await mock.fetch('http://calculator-api/add?x=5&y=3');
+      await mock.fetch('http://calculator-api/subtract?x=10&y=4');
 
       const interactions = mock.getInteractions();
       expect(interactions.length).toBe(2);
@@ -75,8 +75,8 @@ describe('Consumer Registration', () => {
     });
 
     test('should register consumer from captured interactions', async () => {
-      await mock.fetch('http://calculator-api/add?a=1&b=2');
-      await mock.fetch('http://calculator-api/subtract?a=5&b=3');
+      await mock.fetch('http://calculator-api/add?x=1&y=2');
+      await mock.fetch('http://calculator-api/subtract?x=5&y=3');
 
       const interactions = mock.getInteractions();
 

--- a/consumer-2/main.py
+++ b/consumer-2/main.py
@@ -3,9 +3,9 @@
 Consumer-2: A CLI tool that uses the Calculator API for add, multiply, and divide operations.
 
 Usage:
-    python main.py add <a> <b> [--validate]
-    python main.py multiply <a> <b> [--validate]
-    python main.py divide <a> <b> [--validate]
+    python main.py add <x> <y> [--validate]
+    python main.py multiply <x> <y> [--validate]
+    python main.py divide <x> <y> [--validate]
 
 Options:
     --validate  Enable CVT contract validation (default: off)
@@ -86,38 +86,38 @@ def handle_error(error: Exception) -> None:
     sys.exit(1)
 
 
-def add(a: float, b: float, validate: bool) -> None:
+def add(x: float, y: float, validate: bool) -> None:
     """Performs an add operation."""
     try:
         session = create_session(validate)
-        response = session.get(f"{PRODUCER_URL}/add", params={"a": a, "b": b})
+        response = session.get(f"{PRODUCER_URL}/add", params={"x": x, "y": y})
         response.raise_for_status()
         result = response.json()["result"]
-        print(f"{a} + {b} = {result}")
+        print(f"{x} + {y} = {result}")
     except Exception as e:
         handle_error(e)
 
 
-def multiply(a: float, b: float, validate: bool) -> None:
+def multiply(x: float, y: float, validate: bool) -> None:
     """Performs a multiply operation."""
     try:
         session = create_session(validate)
-        response = session.get(f"{PRODUCER_URL}/multiply", params={"a": a, "b": b})
+        response = session.get(f"{PRODUCER_URL}/multiply", params={"x": x, "y": y})
         response.raise_for_status()
         result = response.json()["result"]
-        print(f"{a} * {b} = {result}")
+        print(f"{x} * {y} = {result}")
     except Exception as e:
         handle_error(e)
 
 
-def divide(a: float, b: float, validate: bool) -> None:
+def divide(x: float, y: float, validate: bool) -> None:
     """Performs a divide operation."""
     try:
         session = create_session(validate)
-        response = session.get(f"{PRODUCER_URL}/divide", params={"a": a, "b": b})
+        response = session.get(f"{PRODUCER_URL}/divide", params={"x": x, "y": y})
         response.raise_for_status()
         result = response.json()["result"]
-        print(f"{a} / {b} = {result}")
+        print(f"{x} / {y} = {result}")
     except Exception as e:
         handle_error(e)
 
@@ -133,24 +133,24 @@ def main() -> None:
 
     # Add command
     add_parser = subparsers.add_parser("add", help="Add two numbers")
-    add_parser.add_argument("a", type=float, help="First number")
-    add_parser.add_argument("b", type=float, help="Second number")
+    add_parser.add_argument("x", type=float, help="First number")
+    add_parser.add_argument("y", type=float, help="Second number")
     add_parser.add_argument(
         "--validate", action="store_true", help="Enable CVT contract validation"
     )
 
     # Multiply command
     multiply_parser = subparsers.add_parser("multiply", help="Multiply two numbers")
-    multiply_parser.add_argument("a", type=float, help="First number")
-    multiply_parser.add_argument("b", type=float, help="Second number")
+    multiply_parser.add_argument("x", type=float, help="First number")
+    multiply_parser.add_argument("y", type=float, help="Second number")
     multiply_parser.add_argument(
         "--validate", action="store_true", help="Enable CVT contract validation"
     )
 
     # Divide command
     divide_parser = subparsers.add_parser("divide", help="Divide two numbers")
-    divide_parser.add_argument("a", type=float, help="First number (dividend)")
-    divide_parser.add_argument("b", type=float, help="Second number (divisor)")
+    divide_parser.add_argument("x", type=float, help="First number (dividend)")
+    divide_parser.add_argument("y", type=float, help="Second number (divisor)")
     divide_parser.add_argument(
         "--validate", action="store_true", help="Enable CVT contract validation"
     )
@@ -162,11 +162,11 @@ def main() -> None:
         sys.exit(1)
 
     if args.command == "add":
-        add(args.a, args.b, args.validate)
+        add(args.x, args.y, args.validate)
     elif args.command == "multiply":
-        multiply(args.a, args.b, args.validate)
+        multiply(args.x, args.y, args.validate)
     elif args.command == "divide":
-        divide(args.a, args.b, args.validate)
+        divide(args.x, args.y, args.validate)
 
 
 if __name__ == "__main__":

--- a/consumer-2/tests/README.md
+++ b/consumer-2/tests/README.md
@@ -77,7 +77,7 @@ Tests that use `ContractValidatingSession` to automatically validate all HTTP re
 
 ```python
 session = ContractValidatingSession(validator, auto_validate=True)
-response = session.get(f"{producer_url}/add", params={"a": 5, "b": 3})
+response = session.get(f"{producer_url}/add", params={"x": 5, "y": 3})
 # Validation happens automatically
 ```
 
@@ -87,7 +87,7 @@ Tests that use `MockSession` to generate schema-compliant responses without a re
 
 ```python
 session = MockSession(validator, cache=True)
-response = session.get("http://calculator-api/add", params={"a": 5, "b": 3})
+response = session.get("http://calculator-api/add", params={"x": 5, "y": 3})
 # Response is generated from schema, no real HTTP call
 ```
 
@@ -107,9 +107,9 @@ consumer = validator.register_consumer(RegisterConsumerOptions(used_endpoints=[.
 
 Consumer-2 uses these Calculator API endpoints:
 
-- `GET /add?a={number}&b={number}` - Addition
-- `GET /multiply?a={number}&b={number}` - Multiplication
-- `GET /divide?a={number}&b={number}` - Division
+- `GET /add?x={number}&y={number}` - Addition
+- `GET /multiply?x={number}&y={number}` - Multiplication
+- `GET /divide?x={number}&y={number}` - Division
 
 ## Environment Variables
 

--- a/consumer-2/tests/test_adapter.py
+++ b/consumer-2/tests/test_adapter.py
@@ -36,7 +36,7 @@ class TestHTTPAdapter:
         yield sess
 
     def test_add_with_automatic_validation(self, session, producer_url):
-        response = session.get(f"{producer_url}/add", params={"a": 5, "b": 3})
+        response = session.get(f"{producer_url}/add", params={"x": 5, "y": 3})
 
         assert response.status_code == 200
         assert response.json()["result"] == 8
@@ -50,7 +50,7 @@ class TestHTTPAdapter:
     def test_multiply_with_automatic_validation(self, session, producer_url):
         session.clear_interactions()
 
-        response = session.get(f"{producer_url}/multiply", params={"a": 6, "b": 7})
+        response = session.get(f"{producer_url}/multiply", params={"x": 6, "y": 7})
 
         assert response.status_code == 200
         assert response.json()["result"] == 42
@@ -62,7 +62,7 @@ class TestHTTPAdapter:
     def test_divide_with_automatic_validation(self, session, producer_url):
         session.clear_interactions()
 
-        response = session.get(f"{producer_url}/divide", params={"a": 20, "b": 4})
+        response = session.get(f"{producer_url}/divide", params={"x": 20, "y": 4})
 
         assert response.status_code == 200
         assert response.json()["result"] == 5.0
@@ -74,7 +74,7 @@ class TestHTTPAdapter:
     def test_divide_by_zero_error_validation(self, session, producer_url):
         session.clear_interactions()
 
-        response = session.get(f"{producer_url}/divide", params={"a": 10, "b": 0})
+        response = session.get(f"{producer_url}/divide", params={"x": 10, "y": 0})
 
         assert response.status_code == 400
         assert "error" in response.json()
@@ -86,7 +86,7 @@ class TestHTTPAdapter:
     def test_captures_request_response_details(self, session, producer_url):
         session.clear_interactions()
 
-        session.get(f"{producer_url}/add", params={"a": 100, "b": 200})
+        session.get(f"{producer_url}/add", params={"x": 100, "y": 200})
 
         interactions = session.get_interactions()
         assert len(interactions) == 1
@@ -100,9 +100,9 @@ class TestHTTPAdapter:
     def test_multiple_operations_captured(self, session, producer_url):
         session.clear_interactions()
 
-        session.get(f"{producer_url}/add", params={"a": 1, "b": 2})
-        session.get(f"{producer_url}/multiply", params={"a": 3, "b": 4})
-        session.get(f"{producer_url}/divide", params={"a": 8, "b": 2})
+        session.get(f"{producer_url}/add", params={"x": 1, "y": 2})
+        session.get(f"{producer_url}/multiply", params={"x": 3, "y": 4})
+        session.get(f"{producer_url}/divide", params={"x": 8, "y": 2})
 
         interactions = session.get_interactions()
         assert len(interactions) == 3

--- a/consumer-2/tests/test_manual.py
+++ b/consumer-2/tests/test_manual.py
@@ -19,11 +19,11 @@ import requests
 class TestManualValidation:
 
     def test_add_operation_valid(self, validator, producer_url):
-        response = requests.get(f"{producer_url}/add", params={"a": 5, "b": 3})
+        response = requests.get(f"{producer_url}/add", params={"x": 5, "y": 3})
 
         request = {
             "method": "GET",
-            "path": "/add?a=5&b=3",
+            "path": "/add?x=5&y=3",
             "headers": {},
         }
 
@@ -42,7 +42,7 @@ class TestManualValidation:
     def test_add_missing_result_field(self, validator):
         request = {
             "method": "GET",
-            "path": "/add?a=5&b=3",
+            "path": "/add?x=5&y=3",
             "headers": {},
         }
 
@@ -58,11 +58,11 @@ class TestManualValidation:
         assert len(result["errors"]) > 0
 
     def test_multiply_operation_valid(self, validator, producer_url):
-        response = requests.get(f"{producer_url}/multiply", params={"a": 4, "b": 7})
+        response = requests.get(f"{producer_url}/multiply", params={"x": 4, "y": 7})
 
         request = {
             "method": "GET",
-            "path": "/multiply?a=4&b=7",
+            "path": "/multiply?x=4&y=7",
             "headers": {},
         }
 
@@ -79,11 +79,11 @@ class TestManualValidation:
         assert response.json()["result"] == 28
 
     def test_divide_operation_valid(self, validator, producer_url):
-        response = requests.get(f"{producer_url}/divide", params={"a": 10, "b": 2})
+        response = requests.get(f"{producer_url}/divide", params={"x": 10, "y": 2})
 
         request = {
             "method": "GET",
-            "path": "/divide?a=10&b=2",
+            "path": "/divide?x=10&y=2",
             "headers": {},
         }
 
@@ -100,11 +100,11 @@ class TestManualValidation:
         assert response.json()["result"] == 5.0
 
     def test_divide_by_zero_error_response(self, validator, producer_url):
-        response = requests.get(f"{producer_url}/divide", params={"a": 10, "b": 0})
+        response = requests.get(f"{producer_url}/divide", params={"x": 10, "y": 0})
 
         request = {
             "method": "GET",
-            "path": "/divide?a=10&b=0",
+            "path": "/divide?x=10&y=0",
             "headers": {},
         }
 
@@ -123,7 +123,7 @@ class TestManualValidation:
     def test_error_response_invalid_structure(self, validator):
         request = {
             "method": "GET",
-            "path": "/add?a=invalid&b=3",
+            "path": "/add?x=invalid&y=3",
             "headers": {},
         }
 

--- a/consumer-2/tests/test_mock.py
+++ b/consumer-2/tests/test_mock.py
@@ -34,7 +34,7 @@ class TestMockClient:
     def test_mock_add_response(self, mock_session):
         mock_session.clear_interactions()
 
-        response = mock_session.get("http://calculator-api/add", params={"a": 5, "b": 3})
+        response = mock_session.get("http://calculator-api/add", params={"x": 5, "y": 3})
 
         assert response.status_code == 200
         data = response.json()
@@ -44,7 +44,7 @@ class TestMockClient:
     def test_mock_multiply_response(self, mock_session):
         mock_session.clear_interactions()
 
-        response = mock_session.get("http://calculator-api/multiply", params={"a": 4, "b": 7})
+        response = mock_session.get("http://calculator-api/multiply", params={"x": 4, "y": 7})
 
         assert response.status_code == 200
         data = response.json()
@@ -54,7 +54,7 @@ class TestMockClient:
     def test_mock_divide_response(self, mock_session):
         mock_session.clear_interactions()
 
-        response = mock_session.get("http://calculator-api/divide", params={"a": 10, "b": 2})
+        response = mock_session.get("http://calculator-api/divide", params={"x": 10, "y": 2})
 
         assert response.status_code == 200
         data = response.json()
@@ -64,7 +64,7 @@ class TestMockClient:
     def test_captures_mock_interactions(self, mock_session):
         mock_session.clear_interactions()
 
-        mock_session.get("http://calculator-api/add", params={"a": 10, "b": 20})
+        mock_session.get("http://calculator-api/add", params={"x": 10, "y": 20})
 
         interactions = mock_session.get_interactions()
         assert len(interactions) == 1
@@ -74,11 +74,11 @@ class TestMockClient:
     def test_mock_response_validates_against_schema(self, mock_session, validator):
         mock_session.clear_interactions()
 
-        response = mock_session.get("http://calculator-api/add", params={"a": 1, "b": 1})
+        response = mock_session.get("http://calculator-api/add", params={"x": 1, "y": 1})
         data = response.json()
 
         validation_result = validator.validate(
-            {"method": "GET", "path": "/add?a=1&b=1", "headers": {}},
+            {"method": "GET", "path": "/add?x=1&y=1", "headers": {}},
             {"status_code": 200, "headers": {"content-type": "application/json"}, "body": data},
         )
 
@@ -87,9 +87,9 @@ class TestMockClient:
     def test_captures_all_consumer2_endpoints(self, mock_session):
         mock_session.clear_interactions()
 
-        mock_session.get("http://calculator-api/add", params={"a": 5, "b": 3})
-        mock_session.get("http://calculator-api/multiply", params={"a": 4, "b": 7})
-        mock_session.get("http://calculator-api/divide", params={"a": 10, "b": 2})
+        mock_session.get("http://calculator-api/add", params={"x": 5, "y": 3})
+        mock_session.get("http://calculator-api/multiply", params={"x": 4, "y": 7})
+        mock_session.get("http://calculator-api/divide", params={"x": 10, "y": 2})
 
         interactions = mock_session.get_interactions()
         assert len(interactions) == 3

--- a/consumer-2/tests/test_registration.py
+++ b/consumer-2/tests/test_registration.py
@@ -31,9 +31,9 @@ class TestConsumerRegistration:
     ):
         mock_session.clear_interactions()
 
-        mock_session.get("http://calculator-api/add", params={"a": 5, "b": 3})
-        mock_session.get("http://calculator-api/multiply", params={"a": 4, "b": 7})
-        mock_session.get("http://calculator-api/divide", params={"a": 10, "b": 2})
+        mock_session.get("http://calculator-api/add", params={"x": 5, "y": 3})
+        mock_session.get("http://calculator-api/multiply", params={"x": 4, "y": 7})
+        mock_session.get("http://calculator-api/divide", params={"x": 10, "y": 2})
 
         interactions = mock_session.get_interactions()
         assert len(interactions) == 3
@@ -63,9 +63,9 @@ class TestConsumerRegistration:
     ):
         mock_session.clear_interactions()
 
-        mock_session.get("http://calculator-api/add", params={"a": 1, "b": 2})
-        mock_session.get("http://calculator-api/multiply", params={"a": 3, "b": 4})
-        mock_session.get("http://calculator-api/divide", params={"a": 8, "b": 2})
+        mock_session.get("http://calculator-api/add", params={"x": 1, "y": 2})
+        mock_session.get("http://calculator-api/multiply", params={"x": 3, "y": 4})
+        mock_session.get("http://calculator-api/divide", params={"x": 8, "y": 2})
 
         interactions = mock_session.get_interactions()
 

--- a/producer/calculator-api-v2-breaking.yaml
+++ b/producer/calculator-api-v2-breaking.yaml
@@ -14,13 +14,13 @@ paths:
       summary: Add two numbers
       operationId: add
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number
@@ -45,13 +45,13 @@ paths:
       summary: Subtract two numbers
       operationId: subtract
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number (minuend)
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number (subtrahend)
@@ -76,13 +76,13 @@ paths:
       summary: Multiply two numbers
       operationId: multiply
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number
@@ -107,13 +107,13 @@ paths:
       summary: Divide two numbers
       operationId: divide
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: Dividend
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Divisor (cannot be zero)

--- a/producer/calculator-api.json
+++ b/producer/calculator-api.json
@@ -18,14 +18,14 @@
         "operationId": "add",
         "parameters": [
           {
-            "name": "a",
+            "name": "x",
             "in": "query",
             "required": true,
             "description": "First number",
             "schema": { "type": "number" }
           },
           {
-            "name": "b",
+            "name": "y",
             "in": "query",
             "required": true,
             "description": "Second number",
@@ -58,14 +58,14 @@
         "operationId": "subtract",
         "parameters": [
           {
-            "name": "a",
+            "name": "x",
             "in": "query",
             "required": true,
             "description": "First number (minuend)",
             "schema": { "type": "number" }
           },
           {
-            "name": "b",
+            "name": "y",
             "in": "query",
             "required": true,
             "description": "Second number (subtrahend)",
@@ -98,14 +98,14 @@
         "operationId": "multiply",
         "parameters": [
           {
-            "name": "a",
+            "name": "x",
             "in": "query",
             "required": true,
             "description": "First number",
             "schema": { "type": "number" }
           },
           {
-            "name": "b",
+            "name": "y",
             "in": "query",
             "required": true,
             "description": "Second number",
@@ -138,14 +138,14 @@
         "operationId": "divide",
         "parameters": [
           {
-            "name": "a",
+            "name": "x",
             "in": "query",
             "required": true,
             "description": "Dividend",
             "schema": { "type": "number" }
           },
           {
-            "name": "b",
+            "name": "y",
             "in": "query",
             "required": true,
             "description": "Divisor (cannot be zero)",

--- a/producer/calculator-api.yaml
+++ b/producer/calculator-api.yaml
@@ -14,13 +14,13 @@ paths:
       summary: Add two numbers
       operationId: add
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number
@@ -45,13 +45,13 @@ paths:
       summary: Subtract two numbers
       operationId: subtract
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number (minuend)
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number (subtrahend)
@@ -76,13 +76,13 @@ paths:
       summary: Multiply two numbers
       operationId: multiply
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: First number
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Second number
@@ -107,13 +107,13 @@ paths:
       summary: Divide two numbers
       operationId: divide
       parameters:
-        - name: a
+        - name: x
           in: query
           required: true
           description: Dividend
           schema:
             type: number
-        - name: b
+        - name: y
           in: query
           required: true
           description: Divisor (cannot be zero)

--- a/producer/main.go
+++ b/producer/main.go
@@ -148,29 +148,29 @@ func main() {
 	}
 }
 
-// parseNumbers extracts and validates query parameters a and b.
+// parseNumbers extracts and validates query parameters x and y.
 func parseNumbers(w http.ResponseWriter, r *http.Request) (float64, float64, bool) {
-	aStr := r.URL.Query().Get("a")
-	bStr := r.URL.Query().Get("b")
+	xStr := r.URL.Query().Get("x")
+	yStr := r.URL.Query().Get("y")
 
-	if aStr == "" || bStr == "" {
-		writeError(w, "missing required parameters 'a' and 'b'", http.StatusBadRequest)
+	if xStr == "" || yStr == "" {
+		writeError(w, "missing required parameters 'x' and 'y'", http.StatusBadRequest)
 		return 0, 0, false
 	}
 
-	a, err := strconv.ParseFloat(aStr, 64)
+	x, err := strconv.ParseFloat(xStr, 64)
 	if err != nil {
-		writeError(w, "parameter 'a' must be a valid number", http.StatusBadRequest)
+		writeError(w, "parameter 'x' must be a valid number", http.StatusBadRequest)
 		return 0, 0, false
 	}
 
-	b, err := strconv.ParseFloat(bStr, 64)
+	y, err := strconv.ParseFloat(yStr, 64)
 	if err != nil {
-		writeError(w, "parameter 'b' must be a valid number", http.StatusBadRequest)
+		writeError(w, "parameter 'y' must be a valid number", http.StatusBadRequest)
 		return 0, 0, false
 	}
 
-	return a, b, true
+	return x, y, true
 }
 
 // writeResult writes a successful result response.
@@ -194,12 +194,12 @@ func handleAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a, b, ok := parseNumbers(w, r)
+	x, y, ok := parseNumbers(w, r)
 	if !ok {
 		return
 	}
 
-	writeResult(w, a+b)
+	writeResult(w, x+y)
 }
 
 // handleSubtract handles the /subtract endpoint.
@@ -209,12 +209,12 @@ func handleSubtract(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a, b, ok := parseNumbers(w, r)
+	x, y, ok := parseNumbers(w, r)
 	if !ok {
 		return
 	}
 
-	writeResult(w, a-b)
+	writeResult(w, x-y)
 }
 
 // handleMultiply handles the /multiply endpoint.
@@ -224,12 +224,12 @@ func handleMultiply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a, b, ok := parseNumbers(w, r)
+	x, y, ok := parseNumbers(w, r)
 	if !ok {
 		return
 	}
 
-	writeResult(w, a*b)
+	writeResult(w, x*y)
 }
 
 // handleDivide handles the /divide endpoint.
@@ -239,17 +239,17 @@ func handleDivide(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a, b, ok := parseNumbers(w, r)
+	x, y, ok := parseNumbers(w, r)
 	if !ok {
 		return
 	}
 
-	if b == 0 {
+	if y == 0 {
 		writeError(w, "division by zero is not allowed", http.StatusBadRequest)
 		return
 	}
 
-	writeResult(w, a/b)
+	writeResult(w, x/y)
 }
 
 // handleHealth handles the /health endpoint.


### PR DESCRIPTION
## Summary

- Standardize all API query parameters to use `x` and `y` instead of `a` and `b` across the entire codebase
- Enhance documentation with links and endpoint summaries in Test Files section
- Fix incorrect parameter names in Error Responses section
- Add `build` dependency to `make up` target

## Changes

**OpenAPI Specifications:**
- `producer/calculator-api.yaml` - 8 param name changes
- `producer/calculator-api.json` - 8 param name changes
- `producer/calculator-api-v2-breaking.yaml` - 8 param name changes

**Producer (Go):**
- `producer/main.go` - Updated `parseNumbers()` and all handler functions

**Consumer-1 (Node.js):**
- `consumer-1/main.js` - CLI args and params objects
- All test files updated with new parameter names

**Consumer-2 (Python):**
- `consumer-2/main.py` - CLI args and params dicts
- All test files updated with new parameter names

**Documentation:**
- `README.md` - Endpoint descriptions, curl examples, API Reference
- `CLAUDE.md` - API endpoints description
- `Makefile` - `test-producer` target, `up` depends on `build`

## Test plan

- [x] `make test-producer` - All 5 endpoints working
- [x] `make test-all` - All consumer operations passed
- [x] `make test-contracts` - All CVT validations passed
- [x] `make test` - All 34 unit and integration tests passed
- [x] All README make commands validated manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API query parameter names from `a` and `b` to `x` and `y` across all calculator endpoints (add, subtract, multiply, divide).

* **Tests**
  * Updated test suite to align with new parameter naming.

* **Chores**
  * Updated build system configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->